### PR TITLE
Remove free TLDs for more general info.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
 
 Your bot list:
 
-1. Must have a respectable TLD.
-   - Free TLDs such as `.tk` or `.ga` are probibited
+1. Must use a custom domain name with a respectable, paid TLD.
 2. Must not be a `[xyz].glitch.me` domain.
    - Glitch is acceptable if:
       - Uptime is immaculate


### PR DESCRIPTION
Remove the examples of `.tk` and `.ga` to have more general info and also mention it should be a paid TLD.

This closes #5 

It's a Draft PR for now to keep it open for discussion and changes. If all maintainers agree can this be turned into a full PR.