### PR TITLE
Two separate lists for must-haves & should-haves

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,42 @@
 # Best Practices for Discord Bot Lists
-*Bot lists must meet these minimum requirements to be considered a bot list.*
 
 ---
 
-Your bot list:
+*Bot lists must meet these minimum requirements to be considered a bot list.*
 
-1. Must have a respectable TLD.
+## Your bot list must:
+
+1. have a respectable TLD.
    - Free TLDs such as `.tk` or `.ga` are probibited
-2. Must not be a `[xyz].glitch.me` domain.
+2. not be a `[xyz].glitch.me` domain.
    - Glitch is acceptable if:
       - Uptime is immaculate
       - A custom domain name is used (whilst still following point `1`)
-3. Should not display all bots on the homepage.
-4. Must be fully functioning.
+3. be fully functioning.
    - No broken links/buttons.
-5. Must have consistent uptime.
+4. have consistent uptime.
    - Minor downtime for fixing a problem is fine
+
+---
+
+*Bot lists should meet these requirements to be a good bot list.*
+
+## Your bot list should:
+
+1. not display all bots on the homepage.
+2. not be hosted on Glitch.
+3. have an API with good documentation.
+   - API should support `GET`ting bot information
+      - Uses a JSON body format for data
+   - API should support `POST`ing bot stats
+      - Server/guild count
+      - Shard support
+      - Uses an Authorization header
+      - Uses a JSON body format for data
+4. respond with correct status codes.
+   - All pages that load correctly should respond with 200
+   - Not found (404) pages should respond with a 404 status code
+   - Any API should also send correct status codes
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 3. be fully functioning.
    - No broken links/buttons.
 4. have consistent uptime.
-   - Minor downtime for fixing a problem is fine
+   - Minor downtime for maintenance or fixing issues is fine
 
 ---
 
@@ -26,14 +26,14 @@
 2. not be hosted on Glitch.
 3. have an API with good documentation.
    - API should support `GET`ting bot information
-      - Uses a JSON body format for data
+      - Sends a JSON body for the response data
    - API should support `POST`ing bot stats
       - Server/guild count
       - Shard support
       - Uses an Authorization header
-      - Uses a JSON body format for data
+      - Accepts a JSON body format for data
 4. respond with correct status codes.
-   - All pages that load correctly should respond with 200
+   - All pages that load correctly should respond with a 2xx status code
    - Not found (404) pages should respond with a 404 status code
    - Any API should also send correct status codes
 


### PR DESCRIPTION
This pull request intends to close #1 

Implement two separate lists, with the first containing what we consider to be bare-minimum must-have requirements for any bot list. The second list contains what would be considered best practices that are should-haves for lists but not absolute requirements.