### PR TITLE
Make bot lists use non-free services for hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@
 ## Your bot list must:
 
 1. use a custom domain name with a respectable, paid TLD.
-2. be fully functioning.
+2. not be hosted on any free hosting provider.
+3. be fully functioning.
    - No broken links/buttons.
-3. have consistent uptime.
+4. have consistent uptime.
    - Minor downtime for maintenance or fixing issues is fine
-4. have bot listing requirements (such as no NSFW outside NSFW channels, respect rate-limits, don't respond to other bots, etc.)
-5. blur NSFW profile pictures.
-6. have a ToS and Privacy page.
+5. have bot listing requirements (such as no NSFW outside NSFW channels, respect rate-limits, don't respond to other bots, etc.)
+6. blur NSFW profile pictures.
+7. have a ToS and Privacy page.
 
 ---
 
@@ -22,10 +23,9 @@
 ## Your bot list should:
 
 1. not display all bots on the homepage.
-2. not be hosted on any free hosting provider.
-3. be mobile friendly.
-4. not be paid access only.
-5. have an API with good documentation.
+2. be mobile friendly.
+3. not be paid access only.
+4. have an API with good documentation.
    - API should support `GET`ting bot information
       - Sends a JSON body for the response data
    - API should support `POST`ing bot stats
@@ -33,7 +33,7 @@
       - Shard support
       - Uses an Authorization header
       - Accepts a JSON body format for data
-6. respond with correct status codes.
+5. respond with correct status codes.
    - All pages that load correctly should respond with a 2xx status code
    - Not found (404) pages should respond with a 404 status code
    - Any API should also send correct status codes

--- a/README.md
+++ b/README.md
@@ -7,17 +7,13 @@
 ## Your bot list must:
 
 1. use a custom domain name with a respectable, paid TLD.
-2. not be a `[xyz].glitch.me` domain.
-   - Glitch is acceptable if:
-      - Uptime is immaculate
-      - A custom domain name is used (whilst still following point `1`)
-3. be fully functioning.
+2. be fully functioning.
    - No broken links/buttons.
-4. have consistent uptime.
+3. have consistent uptime.
    - Minor downtime for maintenance or fixing issues is fine
-5. have bot listing requirements (such as no NSFW outside NSFW channels, respect rate-limits, don't respond to other bots, etc.)
-6. blur NSFW profile pictures.
-7. have a ToS and Privacy page.
+4. have bot listing requirements (such as no NSFW outside NSFW channels, respect rate-limits, don't respond to other bots, etc.)
+5. blur NSFW profile pictures.
+6. have a ToS and Privacy page.
 
 ---
 


### PR DESCRIPTION
A respectable, custom, paid for TLD is already a requirement, why should a bot list be hosted on, for example glitch.me [..] most bots which will be listed on that bot list will be using paid for services to host their bot. 