### PR TITLE
Don't allow free hosts. (Specifically glitch.com)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,14 @@
 
 1. use a custom domain name with a respectable, paid TLD.
 2. not be a `[xyz].glitch.me` domain.
-   - Glitch is acceptable if:
-      - Uptime is immaculate
-      - A custom domain name is used (whilst still following point `1`)
-3. be fully functioning.
+3. not be hosted on a free host. (Such as glitch.com)
+4. be fully functioning.
    - No broken links/buttons.
-4. have consistent uptime.
+5. have consistent uptime.
    - Minor downtime for maintenance or fixing issues is fine
-5. have bot listing requirements (such as no NSFW outside NSFW channels, respect rate-limits, don't respond to other bots, etc.)
-6. blur NSFW profile pictures.
-7. have a ToS and Privacy page.
+6. have bot listing requirements (such as no NSFW outside NSFW channels, respect rate-limits, don't respond to other bots, etc.)
+7. blur NSFW profile pictures.
+8. have a ToS and Privacy page.
 
 ---
 


### PR DESCRIPTION
Considering the recent string of downtime with glitch.com (along with the fact that projects get rate-limited after 4k requests making it easy for anyone to bring a bot list down), I think we should not allow free website hosting.

Glitch is, however, releasing a paid plan, which is why it says "not be hosted on a free host", if your paying for the glitch, then it isn't a free host making it ok.