### PR TITLE
Link to GitHub repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,6 @@
 
 ---
 
-If anyone wants to change or add something, please make a pull request.
+If anyone wants to change or add something, please [make a pull request](https://github.com/botblock/discord-botlist-best-practices).
 
 Inspired by [Discord Bot Best Practices](https://github.com/meew0/discord-bot-best-practices)


### PR DESCRIPTION
We should link to this GitHub repository since the content of the readme is displayed on https://botblock.org/lists/best-practices without any indication on *where* you should make the PR.